### PR TITLE
Except `OPTIONS` method from auth filter and set CORS headers.

### DIFF
--- a/src/main/java/net/swmaestro/portal/filter/CorsFilter.java
+++ b/src/main/java/net/swmaestro/portal/filter/CorsFilter.java
@@ -15,9 +15,8 @@ public class CorsFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         response.setHeader("Access-Control-Allow-Origin", "*");
-        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
-        response.setHeader("Access-Control-Allow-Headers", "x-requested-with");
-        response.setHeader("Access-Control-Expose-Headers", "x-requested-with");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+        response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/net/swmaestro/portal/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/net/swmaestro/portal/filter/JWTAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JWTAuthenticationFilter extends AbstractAuthenticationProcessingFil
     public JWTAuthenticationFilter(String defaultFilterProcessesUrl) {
         // Except Signup api(POST `/users`) from authentication.
         super(new AndRequestMatcher(
+                new NegatedRequestMatcher(new AntPathRequestMatcher("/**", "OPTIONS")),
                 new NegatedRequestMatcher(new AntPathRequestMatcher("/users", "POST")),
                 new AntPathRequestMatcher(defaultFilterProcessesUrl)
         ));


### PR DESCRIPTION
## 변경 사항
### 1. Auth 필터에서 `OPTIONS` 메소드 제외

CORS 요청 시 특정 경우에 `OPTION` 메소드로 **사전 요청**을 하게 되는데, 이 때는 `Authorization` 헤더가 날아오지 않는다.
하지만 기존 서버에서는 `OPTION` 메소드로 요청 시에도 `Authorizaiton` 헤더를 검사하고있었고, 따라서 401 Unauthorized 가 반환되고 있었다.
### 2. CORS 헤더 설정

`Access-Control-Request-Method: GET, POST, PUT, DELETE`
`Access-Control-Request-Headers: Authorization, Content-Type`
## Flow 정리
1. 사전 요청  
   브라우저가 요청 전 OPTIONS 사전요청 전송 (Authorization 헤더 안보냄)  
   사용 가능한 Origin, Method, Headers 응답  
2. 본 요청  
   사전요청에서 응답받은 CORS Headers를 보고 사용가능하다면 브라우저가 본요청을 보냄  
## 참고 자료

[(링크) Mozilla Developer Network HTTP 접근 제어(CORS) - 사전 요청](https://developer.mozilla.org/ko/docs/Web/HTTP/Access_control_CORS#사전_요청)
